### PR TITLE
Fixed package name

### DIFF
--- a/raspi-config
+++ b/raspi-config
@@ -9,7 +9,7 @@ if [ $(id -u) -ne 0 ]; then
 fi
 
 if [ ! -x /usr/bin/whiptail ]; then
-  printf "Please install 'newt' package.\n"
+  printf "Please install 'libnewt' package.\n"
   exit 1
 fi
 


### PR DESCRIPTION
Not sure if this changed, but the package-name in the official repos is `libnewt`. Helps to avoid confusion :)
